### PR TITLE
Fix the pipeline to use the correct Webpack/Rollup bundler versions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,38 +5,57 @@ on: [push, pull_request]
 jobs:
   build:
     runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: ./
 
     strategy:
+      fail-fast: false
       matrix:
-        node-version:
-          [
-            { node: 14.x, npm: 7.x },
-            { node: 16.x, npm: 7.x },
-            { node: 18.x, npm: 8.x },
-          ]
-        bundler-version:
-          [
-            { rollup: 1.21.x, webpack: 4.1.x },
-            { rollup: ^1.0.0, webpack: ^4.0.1 },
-            { rollup: ^2.0.0, webpack: 5.0.x },
-            { rollup: ^3.0.0, webpack: ^5.0.0 },
+        test-case: [
+            # Lowest supported versions are 1.21.0 for Rollup and 4.0.1 for Webpack.
+            { node: 14.x, rollup: 1.21.0, webpack: 4.0.1 },
+            { node: 14.x, rollup: ^1.21.0, webpack: ^4.0.1 },
+            { node: 14.x, rollup: ^2.0.0, webpack: 5.0.x },
+            { node: 14.x, rollup: ^3.0.0, webpack: ^5.0.0 },
+
+            { node: 16.x, rollup: 1.21.x, webpack: 4.1.x },
+            { node: 16.x, rollup: ^1.21.0, webpack: ^4.0.1 },
+            { node: 16.x, rollup: ^2.0.0, webpack: 5.0.x },
+            { node: 16.x, rollup: ^3.0.0, webpack: ^5.0.0 },
+
+            # Node 18 only works with Webpack version ^5.61.x.
+            { node: 18.x, rollup: 1.21.x, webpack: 5.61.x },
+            { node: 18.x, rollup: ^1.21.0, webpack: ^5.0.0 },
+            { node: 18.x, rollup: ^2.0.0, webpack: 5.61.x },
+            { node: 18.x, rollup: ^3.0.0, webpack: ^5.0.0 },
           ]
 
     steps:
       - uses: actions/checkout@v3
-      - name: Use Node.js ${{ matrix.node-version.node }}
+
+      - name: Use Node.js ${{ matrix.test-case.node }}
         uses: actions/setup-node@v3
         with:
-          node-version: ${{ matrix.node-version.node }}
+          node-version: ${{ matrix.test-case.node }}
           cache: 'npm'
-      - run: npm install -g npm@${{ matrix.node-version.npm }}
-      - run: npm ci
-      - run: npm install rollup@${{ matrix.bundler-version.rollup }}
+
+      # Underlying wbn-sign requires to use npm v8+
+      - run: npm install -g npm@8
+
+      - name: Install deps
+        run: npm ci
+
+      - name: Install Rollup v${{ matrix.test-case.rollup }}
+        run: npm install --save-dev rollup@${{ matrix.test-case.rollup }}
         working-directory: ./packages/rollup-plugin-webbundle
-      - run: npm install webpack@${{ matrix.bundler-version.webpack }}
+
+      - name: Install Webpack v${{ matrix.test-case.webpack }}
+        run: npm install --save-dev webpack@${{ matrix.test-case.webpack }}
         working-directory: ./packages/webbundle-webpack-plugin
+
       - run: npm run build
-      - run: npm test
+      - run: npm run test
 
   lint:
     runs-on: ubuntu-latest

--- a/package-lock.json
+++ b/package-lock.json
@@ -3349,8 +3349,7 @@
       "dependencies": {
         "mime": "^2.4.4",
         "wbn": "0.0.9",
-        "wbn-sign": "0.0.1",
-        "webpack-sources": "^1.4.3"
+        "wbn-sign": "0.0.1"
       },
       "devDependencies": {
         "esbuild": "^0.17.15",
@@ -3361,7 +3360,7 @@
         "node": ">= 14.0.0"
       },
       "peerDependencies": {
-        "webpack": ">=4.0.0 <6.0.0"
+        "webpack": ">=4.0.1 <6.0.0"
       }
     },
     "packages/webbundle-webpack-plugin/node_modules/@jridgewell/gen-mapping": {
@@ -3876,12 +3875,9 @@
         "randombytes": "^2.1.0"
       }
     },
-    "packages/webbundle-webpack-plugin/node_modules/source-list-map": {
-      "version": "2.0.1",
-      "license": "MIT"
-    },
     "packages/webbundle-webpack-plugin/node_modules/source-map": {
       "version": "0.6.1",
+      "dev": true,
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.10.0"
@@ -4067,14 +4063,6 @@
         "webpack-cli": {
           "optional": true
         }
-      }
-    },
-    "packages/webbundle-webpack-plugin/node_modules/webpack-sources": {
-      "version": "1.4.3",
-      "license": "MIT",
-      "dependencies": {
-        "source-list-map": "^2.0.0",
-        "source-map": "~0.6.1"
       }
     },
     "packages/webbundle-webpack-plugin/node_modules/webpack/node_modules/webpack-sources": {
@@ -6145,8 +6133,7 @@
         "mime": "^2.4.4",
         "wbn": "0.0.9",
         "wbn-sign": "0.0.1",
-        "webpack": "^5.74.0",
-        "webpack-sources": "^1.4.3"
+        "webpack": "^5.74.0"
       },
       "dependencies": {
         "@jridgewell/gen-mapping": {
@@ -6521,11 +6508,9 @@
             "randombytes": "^2.1.0"
           }
         },
-        "source-list-map": {
-          "version": "2.0.1"
-        },
         "source-map": {
-          "version": "0.6.1"
+          "version": "0.6.1",
+          "dev": true
         },
         "source-map-support": {
           "version": "0.5.21",
@@ -6634,13 +6619,6 @@
               "version": "3.2.3",
               "dev": true
             }
-          }
-        },
-        "webpack-sources": {
-          "version": "1.4.3",
-          "requires": {
-            "source-list-map": "^2.0.0",
-            "source-map": "~0.6.1"
           }
         }
       }

--- a/packages/webbundle-webpack-plugin/package.json
+++ b/packages/webbundle-webpack-plugin/package.json
@@ -23,13 +23,12 @@
     "directory": "packages/webbundle-webpack-plugin"
   },
   "peerDependencies": {
-    "webpack": ">=4.0.0 <6.0.0"
+    "webpack": ">=4.0.1 <6.0.0"
   },
   "dependencies": {
     "mime": "^2.4.4",
     "wbn": "0.0.9",
-    "wbn-sign": "0.0.1",
-    "webpack-sources": "^1.4.3"
+    "wbn-sign": "0.0.1"
   },
   "devDependencies": {
     "esbuild": "^0.17.15",


### PR DESCRIPTION
Also make sure that Node 18 will only use webpack v5.61.x+ as lower is not supported.

Also webpack.sources.RawSources is not supported for webpack 4 yet so creating similar object "manually" to pass the webbundle buffer.