### PR TITLE
ts updates

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,2 @@
+node_modules/
+lib/

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,8 +7,9 @@
       "name": "webbundle-plugins",
       "license": "Apache-2.0",
       "workspaces": [
-        "packages/webbundle-webpack-plugin",
-        "packages/rollup-plugin-webbundle"
+        "packages/rollup-plugin-webbundle",
+        "packages/shared",
+        "packages/webbundle-webpack-plugin"
       ],
       "devDependencies": {
         "@types/mime": "^3.0.1",
@@ -3597,6 +3598,10 @@
         "randombytes": "^2.1.0"
       }
     },
+    "node_modules/shared": {
+      "resolved": "packages/shared",
+      "link": true
+    },
     "node_modules/shebang-command": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
@@ -4358,16 +4363,7 @@
         "rollup": ">=1.21.0 <4.0.0"
       }
     },
-    "packages/shared": {
-      "name": "webbundle-plugin-helpers",
-      "version": "0.0.0",
-      "extraneous": true,
-      "dependencies": {
-        "mime": "^2.4.4",
-        "wbn": "0.0.9",
-        "wbn-sign": "0.0.1"
-      }
-    },
+    "packages/shared": {},
     "packages/webbundle-webpack-plugin": {
       "version": "0.1.1",
       "license": "Apache-2.0",
@@ -6925,6 +6921,9 @@
       "requires": {
         "randombytes": "^2.1.0"
       }
+    },
+    "shared": {
+      "version": "file:packages/shared"
     },
     "shebang-command": {
       "version": "2.0.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "webbundle-plugins",
   "scripts": {
-    "test": "rm -rf packages/shared/lib/ && npm run build && tsc -p packages/shared/tsconfig.json && ava; rm -rf packages/shared/lib/",
+    "test": "npm run build && ava",
     "build": "npm run build --workspaces",
     "pack": "npm pack --workspaces",
     "lint": "npm run lint:prettier && npm run lint:eslint",
@@ -14,8 +14,9 @@
   },
   "type": "module",
   "workspaces": [
-    "packages/webbundle-webpack-plugin",
-    "packages/rollup-plugin-webbundle"
+    "packages/rollup-plugin-webbundle",
+    "packages/shared",
+    "packages/webbundle-webpack-plugin"
   ],
   "private": true,
   "license": "Apache-2.0",

--- a/packages/rollup-plugin-webbundle/package.json
+++ b/packages/rollup-plugin-webbundle/package.json
@@ -11,7 +11,7 @@
   "scripts": {
     "prepack": "npm run build && cp ../../LICENSE ./LICENSE",
     "postpack": "rm -f ./LICENSE",
-    "build": "rm -rf lib && esbuild --bundle --packages=external --format=esm --outfile=lib/index.js src/index.ts --platform=node --legal-comments=inline --sourcemap"
+    "build": "rm -rf lib && esbuild --bundle --packages=external --format=esm --outfile=lib/index.js src/index.ts --platform=node --legal-comments=inline --sourcemap --keep-names"
   },
   "type": "module",
   "author": "Kunihiko Sakamoto <ksakamoto@chromium.org>",

--- a/packages/rollup-plugin-webbundle/src/index.ts
+++ b/packages/rollup-plugin-webbundle/src/index.ts
@@ -23,8 +23,8 @@ import {
   addFilesRecursively,
   validateOptions,
   maybeSignWebBundle,
-} from '../../shared/utils.js';
-import { PluginOptions } from '../../shared/types.js';
+} from '../../shared/utils';
+import { PluginOptions } from '../../shared/types';
 
 const defaults = {
   output: 'out.wbn',

--- a/packages/shared/iwa-headers.ts
+++ b/packages/shared/iwa-headers.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { Headers, PluginOptions } from './types.js';
+import { Headers, PluginOptions } from './types';
 
 export const coep: Headers = Object.freeze({
   'cross-origin-embedder-policy': 'require-corp',

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "shared",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "build": "rm -rf lib && tsc"
+  }
+}

--- a/packages/shared/tsconfig.json
+++ b/packages/shared/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "../../base.tsconfig.json",
+  "extends": "../../tsconfig.json",
   "compilerOptions": {
     "outDir": "lib",
     "noEmit": false

--- a/packages/shared/types.ts
+++ b/packages/shared/types.ts
@@ -15,7 +15,7 @@
  */
 
 import { KeyObject } from 'crypto';
-import { FormatVersion } from './wbn-types.js';
+import { FormatVersion } from './wbn-types';
 
 export interface Headers {
   [key: string]: string;

--- a/packages/shared/utils.ts
+++ b/packages/shared/utils.ts
@@ -20,8 +20,8 @@ import mime from 'mime';
 import { KeyObject } from 'crypto';
 import { combineHeadersForUrl, BundleBuilder } from 'wbn';
 import { IntegrityBlockSigner, WebBundleId } from 'wbn-sign';
-import { checkAndAddIwaHeaders, maybeSetIwaDefaults } from './iwa-headers.js';
-import { PluginOptions } from './types.js';
+import { checkAndAddIwaHeaders, maybeSetIwaDefaults } from './iwa-headers';
+import { PluginOptions } from './types';
 
 // If the file name is 'index.html', create an entry for both baseURL/dir/
 // and baseURL/dir/index.html which redirects to the aforementioned. Otherwise

--- a/packages/webbundle-webpack-plugin/package.json
+++ b/packages/webbundle-webpack-plugin/package.json
@@ -13,7 +13,7 @@
   "scripts": {
     "prepack": "npm run build && cp ../../LICENSE ./LICENSE",
     "postpack": "rm -f ./LICENSE",
-    "build": "rm -rf lib && esbuild --bundle --packages=external --format=cjs --outfile=lib/index.cjs src/index.ts --platform=node --legal-comments=inline --sourcemap"
+    "build": "rm -rf lib && esbuild --bundle --packages=external --format=cjs --outfile=lib/index.cjs src/index.ts --platform=node --legal-comments=inline --sourcemap --keep-names"
   },
   "author": "Kunihiko Sakamoto <ksakamoto@chromium.org>",
   "license": "Apache-2.0",

--- a/packages/webbundle-webpack-plugin/src/index.ts
+++ b/packages/webbundle-webpack-plugin/src/index.ts
@@ -23,8 +23,8 @@ import {
   addFilesRecursively,
   validateOptions,
   maybeSignWebBundle,
-} from '../../shared/utils.js';
-import { PluginOptions } from '../../shared/types.js';
+} from '../../shared/utils';
+import { PluginOptions } from '../../shared/types';
 
 const PLUGIN_NAME = 'webbundle-webpack-plugin';
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,19 +5,15 @@
     "target": "es2020",
     "moduleResolution": "node",
     "esModuleInterop": true,
+    "isolatedModules": true,
     "strict": true,
     "declaration": true,
     "newLine": "lf",
-    "outDir": "packages/shared/lib",
     "noImplicitReturns": true,
     "skipLibCheck": true,
     "allowJs": true,
     "noEmit": true
   },
-  "include": [
-    "packages/shared/**/*",
-    "packages/webbundle-webpack-plugin/**/*",
-    "packages/rollup-plugin-webbundle/**/*"
-  ],
-  "exclude": ["node_modules", "lib"]
+  "include": ["packages/**/*"],
+  "exclude": ["**/node_modules", "**/lib"]
 }


### PR DESCRIPTION
- Drop `.js` from imports, rename root tsconfig to let editors pick it up
- Make shared folder an internal package with a build script
- Ignore built files for prettier
- Make sure that names are kept in tact when bundling
