### PR TITLE
Fix Web Bundles's url

### DIFF
--- a/packages/rollup-plugin-webbundle/README.md
+++ b/packages/rollup-plugin-webbundle/README.md
@@ -1,7 +1,7 @@
 # rollup-plugin-webbundle
 
 A Rollup plugin which generates
-[Web Bundles](https://wicg.github.io/webpackage/draft-yasskin-wpack-bundled-exchanges.html)
+[Web Bundles](https://wpack-wg.github.io/bundled-responses/draft-ietf-wpack-bundled-responses.html)
 output. Currently the spec is still a draft, so this package is also in alpha
 until the spec stabilizes.
 


### PR DESCRIPTION
Following url is file not found. This change fixes the url.
https://wicg.github.io/webpackage/draft-yasskin-wpack-bundled-exchanges.html