### PR TITLE
Update Isolated Web App `connect-src` CSP value to match new default

### DIFF
--- a/packages/rollup-plugin-webbundle/README.md
+++ b/packages/rollup-plugin-webbundle/README.md
@@ -94,7 +94,7 @@ export default async () => {
           'cross-origin-opener-policy': 'same-origin',
           'cross-origin-resource-policy': 'same-origin',
           'content-security-policy':
-            "base-uri 'none'; default-src 'self'; object-src 'none'; frame-src 'self' https: blob: data:; connect-src 'self' https:; script-src 'self' 'wasm-unsafe-eval'; img-src 'self' https: blob: data:; media-src 'self' https: blob: data:; font-src 'self' blob: data:; require-trusted-types-for 'script';",
+            "base-uri 'none'; default-src 'self'; object-src 'none'; frame-src 'self' https: blob: data:; connect-src 'self' https: wss:; script-src 'self' 'wasm-unsafe-eval'; img-src 'self' https: blob: data:; media-src 'self' https: blob: data:; font-src 'self' blob: data:; require-trusted-types-for 'script';",
         },
       }),
     ],

--- a/packages/shared/iwa-headers.ts
+++ b/packages/shared/iwa-headers.ts
@@ -29,7 +29,7 @@ export const corp: Headers = Object.freeze({
 export const CSP_HEADER_NAME = 'content-security-policy';
 export const csp: Headers = Object.freeze({
   [CSP_HEADER_NAME]:
-    "base-uri 'none'; default-src 'self'; object-src 'none'; frame-src 'self' https: blob: data:; connect-src 'self' https:; script-src 'self' 'wasm-unsafe-eval'; img-src 'self' https: blob: data:; media-src 'self' https: blob: data:; font-src 'self' blob: data:; require-trusted-types-for 'script'; frame-ancestors 'self';",
+    "base-uri 'none'; default-src 'self'; object-src 'none'; frame-src 'self' https: blob: data:; connect-src 'self' https: wss:; script-src 'self' 'wasm-unsafe-eval'; img-src 'self' https: blob: data:; media-src 'self' https: blob: data:; font-src 'self' blob: data:; require-trusted-types-for 'script'; frame-ancestors 'self';",
 });
 
 // These headers must have these exact values for Isolated Web Apps, whereas the

--- a/packages/webbundle-webpack-plugin/README.md
+++ b/packages/webbundle-webpack-plugin/README.md
@@ -96,7 +96,7 @@ module.exports = async () => {
           'cross-origin-opener-policy': 'same-origin',
           'cross-origin-resource-policy': 'same-origin',
           'content-security-policy':
-            "base-uri 'none'; default-src 'self'; object-src 'none'; frame-src 'self' https: blob: data:; connect-src 'self' https:; script-src 'self' 'wasm-unsafe-eval'; img-src 'self' https: blob: data:; media-src 'self' https: blob: data:; font-src 'self' blob: data:; require-trusted-types-for 'script';",
+            "base-uri 'none'; default-src 'self'; object-src 'none'; frame-src 'self' https: blob: data:; connect-src 'self' https: wss:; script-src 'self' 'wasm-unsafe-eval'; img-src 'self' https: blob: data:; media-src 'self' https: blob: data:; font-src 'self' blob: data:; require-trusted-types-for 'script';",
         },
       }),
     ],


### PR DESCRIPTION
We updated the default required CSP for Isolated Web Apps in
https://github.com/WICG/isolated-web-apps/pull/18. This PR also updates
the Webpack and Rollup plugin to use this new value.